### PR TITLE
caciviclab.slack.com => opencal.slack.com

### DIFF
--- a/opendisclosure/index.html
+++ b/opendisclosure/index.html
@@ -145,7 +145,7 @@
             <dt>Email list</dt>
             <dd><a href="https://groups.google.com/forum/#!forum/opencal">Google Group</a></dd>
             <dt>Chat</dt>
-            <dd><a href="https://caciviclab.slack.com/">caciviclab.slack.com</a></dd>
+            <dd><a href="https://opencal.slack.com/">opencal.slack.com</a></dd>
             <dt>Github</dt>
             <dd><a href="https://github.com/caciviclab">California Civic Lab</a></dd>
           </dl>


### PR DESCRIPTION
I believe this is correct... according to slack, http://caciviclab.slack.com points to nothing.