### PR TITLE
Update contact info and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-California Civic Laboratories
+CA Civic Lab
 =============================
 
-**California Civic Laboratories** is a platform for organizing open data and civic technology projects that can be replicated and scaled throughout California. 
+**CA Civic Lab** is a platform for organizing open data and civic technology projects that can be replicated and scaled throughout California.
 
 ## Who We Are
-**We're a coalition** of Code for America brigades, journalists, reform groups, and public officials improving California governance by making civic information more open and accessible. If you're interested in contributing to **CA Civic Labs**, please [open an issue](/issues) to let us know who you are and how you want to help. 
+**We're a coalition** of Code for America brigades, journalists, reform groups, and public officials improving California governance by making civic information more open and accessible. If you're interested in contributing to **CA Civic Lab**, please [open an issue](/issues) to let us know who you are and how you want to help.
 
 ## Projects
 We're currently working on two projects:
@@ -17,14 +17,14 @@ Note that each of these folders has a README that explains the purpose of the co
 ## How You Can Help
 Pull requests welcome! We just ask that you follow a few guidelines:
 
-* This repo is for creating and updating pages on the [opencalifornia.github.io](http://opencalifornia.github.io/) website.
+* This repo is for creating and updating pages on the [caciviclab.org](https://caciviclab.org/) website.
 * To create or update a page within this repo, please create a new branch.
 * Each folder that contains a page should have a README to help potential collaborators understand how they might contribute.
 * Each folder should contain its own stylesheets, scripts, and other assets.
-* Don't want to create a page on the website? [Use the Wiki instead](https://github.com/opencalifornia/opencalifornia.github.io/wiki).
+* Don't want to create a page on the website? [Use the Wiki instead](https://github.com/caciviclab/caciviclab.github.io/wiki).
 * To create a new project, simply create a new repo. For example, while the [OpenDisclosure page](/opendisclosure) contains information about OpenDisclosure, the ETL content should be a separate project that is linked the OpenDisclosure page.
 
-Questions? [Open an issue](https://github.com/opencalifornia/opencalifornia.github.io/issues).
+Questions? [Open an issue](https://github.com/caciviclab/caciviclab.github.io/issues).
 
 ## Discussions
 To keep everyone in the loop, please [use GitHub issues](/issues) to discuss things whenever possible.

--- a/_config.yml
+++ b/_config.yml
@@ -7,13 +7,13 @@
 
 # Site settings
 title: CA Civic Lab
-email: opencal@googlegroups.com
+email: caciviclab@googlegroups.com
 description: > # this means to ignore newlines until "baseurl:"
-  The California Civic Lab is a platform for organizing open data, civic
+  CA Civic Lab is a platform for organizing open data, civic
   technology, and civic innovation projects that can be replicated and scaled
   throughout the state of California.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://caciviclab.org" # the base hostname & protocol for your site
+url: "https://caciviclab.org" # the base hostname & protocol for your site
 twitter_username: caciviclab
 github_username:  caciviclab
 

--- a/opendisclosure/README.md
+++ b/opendisclosure/README.md
@@ -5,17 +5,20 @@ OpenDisclosure is a platform for organizing campaign finance data that can be re
 
 ## Where do I meet you?
 
-We are collaborating across the state of california.  There are both weekly and monthly meetings which will appear on the [google calendar.](https://groups.google.com/forum/#!forum/opencal)
+We are collaborating across the state of California.  There are both weekly and monthly meetings which will appear on the [google calendar][caciviclab-calendar].
 
-We also listen to issues here on github, meet up to talk about them in [slack](https://opencal.slack.com), and use [trello](https://trello.com/b/StoAokyX) to organize collective efforts. 
+We also listen to issues here on github and meet up to talk about them in [slack](https://opencal.slack.com) to organize collective efforts.
 
 ## How You Can Help
 
-* If you are in the area, check out a [meeting.](https://groups.google.com/forum/#!forum/opencal)
-* If you are remote, then come visit us on [slack.](https://opencal.slack.com)
-* If you want to avoid the business of discussing with people - we want you!  Pull the repo, make some changes, and tell us about it with a github [issue.](https://github.com/opencalifornia/issues)
-* Say you are a fan, who just really wants to lurk and cheer us on.  View the [alpha.](https://caciviclab.com/disclosure)
+* If you are in the area, check out a [meeting][caciviclab-calendar].
+* If you are remote, then come visit us on [slack](https://opencal.slack.com).
+* If you want to avoid the business of discussing with people - we want you!  Pull the repo, make some changes, and tell us about it with a github [issue.](https://github.com/caciviclab/issues)
+* Say you are a fan, who just really wants to lurk and cheer us on. View our
+  [next beta](https://caciviclab.org/odca-jekyll/).
 
 ## Questions?
 
-Questions? [Open an issue](https://github.com/opencalifornia/opencalifornia.github.io/issues).
+Questions? [Open an issue](https://github.com/caciviclab/caciviclab.github.io/issues).
+
+[caciviclab-calendar]: https://calendar.google.com/calendar/embed?src=6uj6li3gabf05o0j81ukmr195s%40group.calendar.google.com&ctz=America%2FLos_Angeles

--- a/opendisclosure/index.html
+++ b/opendisclosure/index.html
@@ -8,8 +8,8 @@ title: OpenDisclosure Oakland
   <h2>{{ page.title }}</h2>
   <h5>We visualize campaign finance data for local Oakland elections.</h5>
   <p>
-    <a class="btn btn-lg btn-success" href="https://github.com/opencalifornia/disclosure-backend" role="button"><i class="fa fa-github"></i></li> Contribute to the project</a>
-    <a class="btn btn-lg btn-primary" href="https://github.com/opencalifornia/disclosure-backend/issues" role="button"><i class="fa fa-bullhorn"></i></li> Open an issue</a>
+    <a class="btn btn-lg btn-success" href="https://github.com/caciviclab/disclosure-backend-static" role="button"><i class="fa fa-github"></i></li> Contribute to the project</a>
+    <a class="btn btn-lg btn-primary" href="https://github.com/caciviclab/disclosure-backend-static/issues" role="button"><i class="fa fa-bullhorn"></i></li> Open an issue</a>
   </p>
 </div>
 
@@ -17,7 +17,7 @@ title: OpenDisclosure Oakland
 <div class="row">
   <div class="col-sm-12">
     <h3>About ODCa - Welcome!</h3><hr>
-    <p>Welcome to Open Disclosure (ODCa)! ODCa is California’s first online source for local campaign finance data from city and counties across the state. ODCa combines campaign finance data from local cities and counties to create a comprehensive picture about who is influencing elections state-wide. We track contributions and expenditures to candidates and ballot measures at the local level. We hope to be ready for the 2018 Election Season.</p>
+    <p>Welcome to Open Disclosure California (ODCa)! ODCa is California’s first online source for local campaign finance data from city and counties across the state. ODCa combines campaign finance data from local cities and counties to create a comprehensive picture about who is influencing elections state-wide. We track contributions and expenditures to candidates and ballot measures at the local level. We hope to be ready for the 2018 Election Season.</p>
     <h5>Our site is live at <a href="http://www.opendisclosure.io/#!/">opendisclosure.io</a></h5>
     <h5>Mock-ups are here: <a href="https://drive.google.com/drive/folders/18gBQCNYWM8m123EvbffQVZC7nvVxiPT_">version 25</a></h5>
 
@@ -28,7 +28,7 @@ title: OpenDisclosure Oakland
   <div class="col-sm-12">
     <h3>Help wanted</h3><hr>
     <p>Open Disclosure is a group of volunteer civic hackers passionate about open data, transparency and shining light on the funding that fuels California’s electoral campaigns. We're currently working with Code for America Brigades and volunteers across California to create a website that any community in the state can use to make their campaign finance data transparent and easy to understand.</p>
-    <p>We're looking for help across the board, technical and non-technical background. Let us know if you can help, or look through our <a href="https://github.com/opencalifornia/disclosure-backend/issues">Github issues</a> for something interesting.</p>
+    <p>We're looking for help across the board, technical and non-technical background. Let us know if you can help, or look through our <a href="https://waffle.io/caciviclab/disclosure-backend">user stories on Waffle</a> for something interesting.</p>
   </div>
 </div>
 <div class="row">
@@ -73,7 +73,7 @@ title: OpenDisclosure Oakland
     <div class="panel panel-default panel-body">
       <h4>City of Oakland</h4>
       <p>A project by OpenOakland and the Public Ethics Commission displaying data for the 2014 Mayoral Election</p>
-      <a class="btn btn-default btn-primary" href="http://www.opendisclosure.io/" target="_blank"><i class="fa fa-rocket"></i> See it in Action</a>
+      <a class="btn btn-default btn-primary" href="http://2014.opendisclosure.io/" target="_blank"><i class="fa fa-rocket"></i> See it in Action</a>
       <a class="btn btn-default btn-default" href="https://github.com/openoakland/opendisclosure" target="_blank"><i class="fa fa-github"></i> GitHub</a>
     </div>
   </div>
@@ -149,11 +149,11 @@ title: OpenDisclosure Oakland
     <h4 id="contact">Contact</h4>
     <dl>
       <dt>Email list</dt>
-      <dd><a href="https://groups.google.com/forum/#!forum/opencal">Google Group</a></dd>
+      <dd><a href="https://groups.google.com/forum/#!forum/caciviclab">Google Group</a></dd>
       <dt>Chat</dt>
       <dd><a href="http://slack.caciviclab.org/">slack.caciviclab.org</a></dd>
       <dt>Github</dt>
-      <dd><a href="https://github.com/caciviclab">California Civic Lab</a></dd>
+      <dd><a href="https://github.com/caciviclab">CA Civic Lab</a></dd>
     </dl>
   </div>
   <div class="col-sm-6">

--- a/state-agencies/LICENSE
+++ b/state-agencies/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 opencalifornia
+Copyright (c) 2014 CA Civic Lab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/state-agencies/README.md
+++ b/state-agencies/README.md
@@ -1,9 +1,5 @@
-OpenCalifornia
-========================
+# California Open Data Index
 
-OpenCalifornia is a coalition of Code for America brigades in California.
-
-## About this Project
 We're crowdsourcing the status of state agency open data practices. The State of California currently lacks a coordinated and strategic open data strategy. However, there are pockets of activity whereby some departments are publishing their datasets in machine-readable formats. This project exists to track that progress.
 
 ## How You Can Help
@@ -55,9 +51,9 @@ key | value
 **sorta** | Hmmmmm... it's hard to say. It looks like someone made a decent attempt at this, but there's definitely room for improvement.
 **no** | No means no.
 
-That's it. Too confusing? [Open an issue](https://github.com/opencalifornia/opencalifornia.github.io/issues) instead.
+That's it. Too confusing? [Open an issue](https://github.com/caciviclab/caciviclab.github.io/issues) instead.
 
 ## Developing Locally
 If you decide to pull down this repo, you'll need to use Firefox or Safari to preview changes. Chrome's [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) will prevent you from consuming the data.json file. Otherwise, this is just static html with some AngularJS.
 
-This is in very early development. If you plan on adding major features or changing the data schema, please give us a heads-up by opening an [issue](https://github.com/opencalifornia/opencalifornia.github.io/issues).
+This is in very early development. If you plan on adding major features or changing the data schema, please give us a heads-up by opening an [issue](https://github.com/caciviclab/caciviclab.github.io/issues).


### PR DESCRIPTION
- Update the google group
- Consistent naming of CA Civic Lab
- Update links referring to opencal